### PR TITLE
Fix the failure memory order argument to atomic_compare_exchange_strong explicit

### DIFF
--- a/platform/common/queue/lock_free_queue.h
+++ b/platform/common/queue/lock_free_queue.h
@@ -41,7 +41,7 @@ class LockFreeQueue {
       bool old_v = true;
       if (need_notify_.compare_exchange_strong(old_v, false,
                                                std::memory_order_acq_rel,
-                                               std::memory_order_acq_rel)) {
+                                               std::memory_order_acquire)) {
         std::lock_guard<std::mutex> lk(mutex_);
         cv_.notify_all();
         return;


### PR DESCRIPTION
The failure memory order cannot be release or acq_rel. Clang since llvm/llvm-project@fed5644 diagnoses an invalid argument.