### PR TITLE
[License]Add the missing license file

### DIFF
--- a/.licenserc.yaml
+++ b/.licenserc.yaml
@@ -23,6 +23,7 @@ header:
     - 'NOTICE'
     - 'LICENSE'
     - 'documents/doxygen/.gitignore'
+    - 'third_party/loc_script/src/index.js'
 
 
 

--- a/LICENSE
+++ b/LICENSE
@@ -207,6 +207,34 @@ and license terms. Your use of these submodules is subject to the terms and
 conditions of the following licenses.
 
 ================================================================
+MIT licenses
+================================================================
+
+third_party/loc_script/src/index.js files from  https://github.com/shadowmoose/GHA-LoC-Badge/blob/1.0.0/src/index.js
+
+MIT License
+
+Copyright (c) 2020 Mike
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+================================================================
 
 ================================================================
 Apache-2.0 licenses

--- a/third_party/loc_script/src/index.js
+++ b/third_party/loc_script/src/index.js
@@ -1,20 +1,5 @@
-/*
-*    Licensed to the Apache Software Foundation (ASF) under one or more
-*    contributor license agreements.  See the NOTICE file distributed with
-*    this work for additional information regarding copyright ownership.
-*    The ASF licenses this file to You under the Apache License, Version 2.0
-*    (the "License"); you may not use this file except in compliance with
-*    the License.  You may obtain a copy of the License at
-*   
-*    http://www.apache.org/licenses/LICENSE-2.0
-*   
-*    Unless required by applicable law or agreed to in writing, software
-*    distributed under the License is distributed on an "AS IS" BASIS,
-*    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-*    See the License for the specific language governing permissions and
-*    limitations under the License.
-*/
-// This script is from https://github.com/shadowmoose/GHA-LoC-Badge/blob/master/src/index.js
+// This script is from https://github.com/shadowmoose/GHA-LoC-Badge/blob/1.0.0/src/index.js
+// Using the MIT license
 
 const { badgen } = require('badgen');
 const fs = require('fs').promises;


### PR DESCRIPTION
- FYI https://infra.apache.org/licensing-howto.html#permissive-deps

According to the MIT License, when distributing source code, we must include the corresponding LICENSE file. Additionally, the index file essentially remains under the MIT License, as we cannot change its license header to an ASF license header.
