### PR TITLE
Integrate clangd Autocomplete Support into Bazel C++ Project

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,6 +1,24 @@
 workspace(name = "com_resdb_nexres")
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+
+http_archive(
+    name = "hedron_compile_commands",
+    #Replace the commit hash (4f28899228fb3ad0126897876f147ca15026151e) with the latest commit hash from the repo
+    url = "https://github.com/hedronvision/bazel-compile-commands-extractor/archive/4f28899228fb3ad0126897876f147ca15026151e.tar.gz",
+    strip_prefix = "bazel-compile-commands-extractor-4f28899228fb3ad0126897876f147ca15026151e",
+)
+load("@hedron_compile_commands//:workspace_setup.bzl", "hedron_compile_commands_setup")
+hedron_compile_commands_setup()
+load("@hedron_compile_commands//:workspace_setup_transitive.bzl", "hedron_compile_commands_setup_transitive")
+hedron_compile_commands_setup_transitive()
+load("@hedron_compile_commands//:workspace_setup_transitive_transitive.bzl", "hedron_compile_commands_setup_transitive_transitive")
+hedron_compile_commands_setup_transitive_transitive()
+load("@hedron_compile_commands//:workspace_setup_transitive_transitive_transitive.bzl", "hedron_compile_commands_setup_transitive_transitive_transitive")
+hedron_compile_commands_setup_transitive_transitive_transitive()
+
+
 load("//:repositories.bzl", "nexres_repositories")
 
 nexres_repositories()


### PR DESCRIPTION
This PR introduces configuration changes to enable autocomplete functionality for C++ development in a Bazel-based project using clangd as the Language Server Protocol (LSP). The key changes include:

1. Addition of Official Bazel Autocomplete Support from [hedronvision/bazel-compile-commands-extractor](https://github.com/hedronvision/bazel-compile-commands-extractor)

2. Run the command  ```bazel run @hedron_compile_commands//:refresh_all```. Generates a compile_command.json

3.  Provides Autocomplete, GotoDefinition, Signature Hover etc. 

4. Tested on Ubuntu 20.04 on neovim 0.10.2.
<img width="2048" alt="Screenshot 2024-11-09 at 12 33 14 AM" src="https://github.com/user-attachments/assets/30a6bc74-7260-4c71-ab3c-29ad49e8dba9">
<img width="2048" alt="Screenshot 2024-11-09 at 12 32 22 AM" src="https://github.com/user-attachments/assets/c180698a-3a57-4d37-adc5-d583b7b3f17d">



