### PR TITLE
Fix smart contract addressing and storage

### DIFF
--- a/executor/contract/manager/address_manager.cpp
+++ b/executor/contract/manager/address_manager.cpp
@@ -43,7 +43,7 @@ bool AddressManager::Exist(const Address& address) {
 }
 
 Address AddressManager::CreateContractAddress(const Address& owner) {
-  return eevm::generate_address(owner, 0u);
+  return eevm::generate_address(owner, rand());
 }
 
 std::string AddressManager::AddressToHex(const Address& address) {

--- a/executor/contract/manager/global_state.cpp
+++ b/executor/contract/manager/global_state.cpp
@@ -17,7 +17,6 @@
  * under the License.
  */
 
-
 #include "executor/contract/manager/global_state.h"
 
 #include <glog/logging.h>
@@ -30,16 +29,15 @@ using eevm::Address;
 using eevm::Code;
 using eevm::SimpleAccount;
 
-
 uint256_t AccountToAddress(const eevm::Address& account) {
-    std::vector<uint8_t> code;
-    code.resize(64);
-    std::fill(code.begin(), code.end(), 0);
-    eevm::to_big_endian(account, code.data());
+  std::vector<uint8_t> code;
+  code.resize(64);
+  std::fill(code.begin(), code.end(), 0);
+  eevm::to_big_endian(account, code.data());
 
-    uint8_t h[32];
-    eevm::keccak_256(code.data(), static_cast<unsigned int>(64), h);
-    return eevm::from_big_endian(h, sizeof(h));
+  uint8_t h[32];
+  eevm::keccak_256(code.data(), static_cast<unsigned int>(64), h);
+  return eevm::from_big_endian(h, sizeof(h));
 }
 
 GlobalState::GlobalState(resdb::Storage* storage) : storage_(storage) {}
@@ -59,7 +57,7 @@ AccountState GlobalState::get(const Address& addr) {
 
 AccountState GlobalState::create(const Address& addr, const uint256_t& balance,
                                  const Code& code) {
-  Insert({SimpleAccount(addr, balance, code), GlobalView(storage_)});
+  Insert({SimpleAccount(addr, balance, code), GlobalView(addr, storage_)});
 
   return get(addr);
 }
@@ -79,8 +77,10 @@ std::string GlobalState::GetBalance(const eevm::Address& account) {
   return storage_->GetValue(eevm::to_hex_string(AccountToAddress(account)));
 }
 
-int GlobalState::SetBalance(const eevm::Address& account, const uint256_t& balance) {
-  return storage_->SetValue(eevm::to_hex_string(AccountToAddress(account)), eevm::to_hex_string(balance));
+int GlobalState::SetBalance(const eevm::Address& account,
+                            const uint256_t& balance) {
+  return storage_->SetValue(eevm::to_hex_string(AccountToAddress(account)),
+                            eevm::to_hex_string(balance));
 }
 
 }  // namespace contract

--- a/executor/contract/manager/global_view.cpp
+++ b/executor/contract/manager/global_view.cpp
@@ -17,7 +17,6 @@
  * under the License.
  */
 
-
 #include "executor/contract/manager/global_view.h"
 
 #include <glog/logging.h>
@@ -27,14 +26,18 @@
 namespace resdb {
 namespace contract {
 
-GlobalView::GlobalView(resdb::Storage* storage) : storage_(storage) {}
+GlobalView::GlobalView(const Address& addr, resdb::Storage* storage)
+    : address_(addr), storage_(storage) {}
 
 void GlobalView::store(const uint256_t& key, const uint256_t& value) {
-  storage_->SetValue(eevm::to_hex_string(key), eevm::to_hex_string(value));
+  storage_->SetValue(
+      eevm::to_hex_string(address_) + ":" + eevm::to_hex_string(key),
+      eevm::to_hex_string(value));
 }
 
 uint256_t GlobalView::load(const uint256_t& key) {
-  return eevm::to_uint256(storage_->GetValue(eevm::to_hex_string(key)));
+  return eevm::to_uint256(storage_->GetValue(eevm::to_hex_string(address_) +
+                                             ":" + eevm::to_hex_string(key)));
 }
 
 bool GlobalView::remove(const uint256_t& key) { return true; }

--- a/executor/contract/manager/global_view.h
+++ b/executor/contract/manager/global_view.h
@@ -21,15 +21,16 @@
 
 #include <map>
 
-#include "eEVM/storage.h"
 #include "chain/storage/storage.h"
+#include "eEVM/storage.h"
+#include "executor/contract/manager/utils.h"
 
 namespace resdb {
 namespace contract {
 
 class GlobalView : public eevm::Storage {
  public:
-  GlobalView(resdb::Storage* storage);
+  GlobalView(const Address& address, resdb::Storage* storage);
   virtual ~GlobalView() = default;
 
   void store(const uint256_t& key, const uint256_t& value) override;
@@ -37,6 +38,7 @@ class GlobalView : public eevm::Storage {
   bool remove(const uint256_t& key) override;
 
  private:
+  const Address address_;
   resdb::Storage* storage_;
 };
 

--- a/repositories.bzl
+++ b/repositories.bzl
@@ -7,9 +7,9 @@ def nexres_repositories():
     maybe(
         http_archive,
         name = "eEVM",
-        strip_prefix = "eEVM-118a9355d023748318a318bc07fc79063f015a94",
-        sha256 = "e86568aec425405fd8a48bbe487edeae4c0641be23b19411288e3b736018e1b6",
-        url = "https://github.com/microsoft/eEVM/archive/118a9355d023748318a318bc07fc79063f015a94.tar.gz",
+        strip_prefix = "eEVM-05efed8658b4e10a21253df8408b1f9bdb6f1445",
+        sha256 = "95652edde062b9be7a66cfc1ba32f3f8f08855539aac007492727dc2d9f36f7d",
+        url = "https://github.com/microsoft/eEVM/archive/05efed8658b4e10a21253df8408b1f9bdb6f1445.tar.gz",
         build_file = "@com_resdb_nexres//third_party:eEVM.BUILD",
     )
     maybe(

--- a/service/tools/contract/service_tools/start_contract_service.sh
+++ b/service/tools/contract/service_tools/start_contract_service.sh
@@ -1,5 +1,3 @@
-<<<<<<< HEAD
-=======
 #
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
@@ -18,7 +16,6 @@
 # specific language governing permissions and limitations
 # under the License.
 #
->>>>>>> master
 killall -9 contract_service
 
 SERVER_PATH=./bazel-bin/service/contract/contract_service


### PR DESCRIPTION
This commit fixes the following issues:

- New contract addresses are generated with a random nonce instead of 0. This allows an account owner to deploy multiple contracts without address conflict.
- When storing, GlobalView passes both the contract address and the key argument to the underlying storage as key instead of just the key argument. This allows different instances of the same contract to store separate state values under the same state name.
- Update eEVM dependency.
- In contract_tools, I added the missing ":f:" to getopt_long. This allows users to pass config file to contract_tools.
- Remove the merge conflict markers from `start_contract_service.sh`.
- clang-format fixed some formatting issues.