### PR TITLE
Smart contract fixes: address validation, balance key prefix, config + script cleanup

### DIFF
--- a/executor/contract/manager/global_state.cpp
+++ b/executor/contract/manager/global_state.cpp
@@ -76,11 +76,13 @@ void GlobalState::Insert(const StateEntry& p) {
 }
 
 std::string GlobalState::GetBalance(const eevm::Address& account) {
-  return storage_->GetValue(eevm::to_hex_string(AccountToAddress(account)));
+  std::string key = "contract_balance_" + eevm::to_hex_string(AccountToAddress(account));
+  return storage_->GetValue(key);
 }
 
 int GlobalState::SetBalance(const eevm::Address& account, const uint256_t& balance) {
-  return storage_->SetValue(eevm::to_hex_string(AccountToAddress(account)), eevm::to_hex_string(balance));
+  std::string key = "contract_balance_" + eevm::to_hex_string(AccountToAddress(account));
+  return storage_->SetValue(key, eevm::to_hex_string(balance));
 }
 
 }  // namespace contract

--- a/service/tools/config/server/contract_server.config
+++ b/service/tools/config/server/contract_server.config
@@ -1,0 +1,36 @@
+{
+  region : {
+    replica_info : {
+      id:1,
+      ip:"127.0.0.1",
+      port: 10006,
+    },
+    replica_info : {
+      id:2,
+      ip:"127.0.0.1",
+      port: 10007,
+    },
+    replica_info : {
+      id:3,
+      ip:"127.0.0.1",
+      port: 10008,
+    },
+    replica_info : {
+      id:4,
+      ip:"127.0.0.1",
+      port: 10009,
+    },
+    region_id: 2,
+  },
+  self_region_id:2,
+  leveldb_info : {
+    write_buffer_size_mb:128,
+    write_batch_size:1,
+    enable_block_cache: true,
+    block_cache_capacity: 100
+  },
+  require_txn_validation:true,
+  enable_viewchange:false,
+  enable_resview:true,
+  enable_faulty_switch:false
+}

--- a/service/tools/contract/service_tools/start_contract_service.sh
+++ b/service/tools/contract/service_tools/start_contract_service.sh
@@ -1,5 +1,3 @@
-<<<<<<< HEAD
-=======
 #
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
@@ -18,7 +16,6 @@
 # specific language governing permissions and limitations
 # under the License.
 #
->>>>>>> master
 killall -9 contract_service
 
 SERVER_PATH=./bazel-bin/service/contract/contract_service

--- a/service/tools/kv/api_tools/contract_service_tools.cpp
+++ b/service/tools/kv/api_tools/contract_service_tools.cpp
@@ -32,6 +32,23 @@ using resdb::GenerateResDBConfig;
 using resdb::ResDBConfig;
 using resdb::contract::ContractClient;
 
+bool IsValidAddress(const std::string& address) {
+    if (address.length() != 42) {
+        return false;
+    }
+
+    if (address.substr(0, 2) != "0x") {
+        return false;
+    }
+
+    for (size_t i = 2; i < address.length(); ++i) {
+        if (!std::isxdigit(address[i])) {
+            return false;
+        }
+    }
+    return true;
+}
+
 void ShowUsage() {
   printf(
       "<cmd> -c <config> -m <caller address> -n <contract name> -p <contact "
@@ -149,6 +166,11 @@ int main(int argc, char** argv) {
     contract_address = GetValue(js, "owner_address");
     params = GetValue(js, "init_params");
 
+    if (!IsValidAddress(contract_address)) {
+        printf("ERROR: Invalid owner address format: %s\n", contract_address.c_str());
+        return 1;
+    }
+
     printf("contract path %s cmd %s contract name %s caller_address %s init params %s\n", contract_path.c_str(), cmd.c_str(), contract_name.c_str(), contract_address.c_str(), params.c_str());
 
     std::vector<std::string> init_params;
@@ -163,6 +185,16 @@ int main(int argc, char** argv) {
     func_name = GetValue(js, "func_name");
     params = GetValue(js, "params");
 
+    if (!IsValidAddress(caller_address)) {
+        printf("ERROR: Invalid caller address format: %s\n", caller_address.c_str());
+        return 1;
+    }
+
+    if (!IsValidAddress(contract_address)) {
+        printf("ERROR: Invalid contract address format: %s\n", contract_address.c_str());
+        return 1;
+    }
+
     printf(
         "execute\n caller address:%s\n contract address: %s\n func: %s\n "
         "params:%s\n",
@@ -176,11 +208,24 @@ int main(int argc, char** argv) {
   }
   else if (cmd == "get_balance") {
     std::string address = GetValue(js, "address");
+
+    // Validate address format
+    if (!IsValidAddress(address)) {
+        printf("ERROR: Invalid address format: %s\n", address.c_str());
+        return 1;
+    }
+
     auto balance_or = client.GetBalance(address);
     printf("get address %s balance %s\n", address.c_str(), (*balance_or).c_str());
   } else if (cmd == "set_balance") {
     std::string address = GetValue(js, "address");
     std::string balance = GetValue(js, "balance");
+
+    // Validate address format
+    if (!IsValidAddress(address)) {
+        printf("ERROR: Invalid address format: %s\n", address.c_str());
+        return 1;
+    }
     printf("address %s balance %s\n", address.c_str(), balance.c_str());
     auto ret = client.SetBalance(address, balance);
     printf("set address %s balance %s ret %s\n", address.c_str(), balance.c_str(), (*ret).c_str());


### PR DESCRIPTION
### Summary
- **GlobalState balance keying**: Use `contract_balance_<address>` for `GetBalance`/`SetBalance` to avoid key collisions.
- **Input validation**: Add strict EVM-style address checks (0x + 40 hex chars) to tool commands:
  - init owner address
  - execute caller and contract addresses
  - get_balance/set_balance addresses
- **New server config**: Add `service/tools/config/server/contract_server.config` with local 4-node setup, LevelDB tuning, and consensus flags.
- **Script cleanup**: Remove merge markers from `start_contract_service.sh`; retain license header and ensure clean startup.