### PR TITLE
Issue 193: race condition in benchmark script

### DIFF
--- a/scripts/deploy/script/deploy_local.sh
+++ b/scripts/deploy/script/deploy_local.sh
@@ -112,7 +112,7 @@ fi
 idx=1
 for ip in ${deploy_iplist[@]};
 do
-  run_one_cmd "mkdir -p ${home_path}/${main_folder}/$idx" &
+  run_one_cmd "mkdir -p ${home_path}/${main_folder}/$idx"
   ((count++))
   ((idx++))
 done


### PR DESCRIPTION
PR to resolve https://github.com/apache/incubator-resilientdb/issues/193

Only change:
`incubator-resilientdb/scripts/deploy/script/deploy_local.sh` line 115

`run_one_cmd "mkdir -p ${home_path}/${main_folder}/$idx" &`
changed to
`run_one_cmd "mkdir -p ${home_path}/${main_folder}/$idx"`


