### PR TITLE
fix(rescontract): switch to JSON config for contract_tools

### DIFF
--- a/ecosystem/smart-contract/rescontract/index.js
+++ b/ecosystem/smart-contract/rescontract/index.js
@@ -163,7 +163,19 @@ program
         process.exit(1);
       }
 
-      await handleExecFile(commandPath, ['create', '-c', configPath]);
+      const tempConfigPath = path.join(os.tmpdir(), `rescontract_config_${Date.now()}.json`);
+      const tempConfig = {
+        command: 'create_account'
+      };
+      fs.writeFileSync(tempConfigPath, JSON.stringify(tempConfig));
+
+      try {
+        await handleExecFile(commandPath, ['-c', configPath, '--config_file', tempConfigPath]);
+      } finally {
+        if (fs.existsSync(tempConfigPath)) {
+          fs.unlinkSync(tempConfigPath);
+        }
+      }
     } catch (error) {
       logger.error(`Error executing create command: ${error.message}`);
       console.error(`Error: ${error.message}`);
@@ -265,18 +277,21 @@ program
         'contract_tools'
       );
 
+      const tempConfigPath = path.join(os.tmpdir(), `rescontract_config_${Date.now()}.json`);
+      const tempConfig = {
+        command: 'deploy',
+        contract_path: contract,
+        contract_name: name,
+        contract_address: owner,
+        init_params: args
+      };
+      fs.writeFileSync(tempConfigPath, JSON.stringify(tempConfig));
+
       const argList = [
-        'deploy',
         '-c',
         configPath,
-        '-p',
-        contract,
-        '-n',
-        name,
-        '-a',
-        args,
-        '-m',
-        owner,
+        '--config_file',
+        tempConfigPath
       ];
 
       const output = await handleSpawnProcess(commandPath, argList);

--- a/ecosystem/smart-contract/rescontract/package-lock.json
+++ b/ecosystem/smart-contract/rescontract/package-lock.json
@@ -1,18 +1,18 @@
 {
   "name": "rescontract-cli",
-  "version": "1.1.0",
+  "version": "1.2.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rescontract-cli",
-      "version": "1.1.0",
-      "license": "MIT",
+      "version": "1.2.5",
+      "license": "Apache",
       "dependencies": {
-        "commander": "^9.4.0",
-        "fs": "^0.0.1-security",
+        "commander": "^9.5.0",
         "fs-extra": "^10.0.0",
         "inquirer": "^8.2.4",
+        "js-yaml": "^4.1.0",
         "winston": "^3.13.0"
       },
       "bin": {
@@ -80,6 +80,12 @@
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "license": "Python-2.0"
     },
     "node_modules/async": {
       "version": "3.2.5",
@@ -326,11 +332,6 @@
       "resolved": "https://registry.npmjs.org/fn.name/-/fn.name-1.1.0.tgz",
       "integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw=="
     },
-    "node_modules/fs": {
-      "version": "0.0.1-security",
-      "resolved": "https://registry.npmjs.org/fs/-/fs-0.0.1-security.tgz",
-      "integrity": "sha512-3XY9e1pP0CVEUCdj5BmfIZxRBTSDycnbqhIOGec9QYtmVH2fbLpj86CFWkrNOkt/Fvty4KZG5lTglL9j/gJ87w=="
-    },
     "node_modules/fs-extra": {
       "version": "10.1.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
@@ -458,6 +459,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/js-yaml": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
       }
     },
     "node_modules/jsonfile": {


### PR DESCRIPTION
Updated the rescontract CLI to use JSON-based configuration when invoking the underlying C++ contract_tools binary.

Previously, the CLI attempted to pass parameters (contract path, name, owner, args) as individual command-line flags, which were not supported by the C++ tool.

Changes:
- Modified `index.js` to generate a temporary JSON configuration file for [create_account](cci:1://file:///Users/vikhas/Desktop/resdb_app/resilientdb/MCP_mod/res-mcp2.py:984:0-996:51) and [deploy](cci:1://file:///Users/vikhas/Desktop/resdb_app/resilientdb/MCP_mod/res-mcp2.py:945:0-962:45) commands.
- Updated the `spawn` arguments to pass this JSON file via the `--config_file` flag.
- Ensures correct parameter parsing and compatibility with the `contract_tools` binary.