### PR TITLE
Fix installation and build on current Ubuntu and arm64

### DIFF
--- a/INSTALL.sh
+++ b/INSTALL.sh
@@ -1,3 +1,4 @@
+#!/bin/sh
 #
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
@@ -17,50 +18,90 @@
 # under the License.
 #
 
-#!/bin/bash
+# Abort on the first failing command so a broken install cannot report success.
+set -eu
 
+# Bazelisk release to install. Checksums are the values published alongside the
+# release as bazelisk-linux-<arch>.sha256. Bump all three together.
+# These cover the Bazelisk launcher itself. Bazelisk then fetches the Bazel
+# release named in .bazelversion, which since v1.29.0 it authenticates with an
+# embedded verification key rather than against a hash recorded here.
+BAZELISK_VERSION="v1.29.0"
+BAZELISK_SHA256_amd64="5a408715e932c0250d28bd84555f12edbf70117de42f9181691c736eacc4a992"
+BAZELISK_SHA256_arm64="e20e8b0f4f240091b7a55bf17b9398bd4f40ee70ae0208dff95dd4c445fb4010"
+BAZEL_BIN="/usr/local/bin/bazel"
 
-sudo apt update
-sudo apt install apt-transport-https curl gnupg -y
-sudo apt-get install protobuf-compiler -y
-sudo apt-get install rapidjson-dev -y
+# Run from the checkout root so Bazelisk resolves this repository's
+# .bazelversion rather than whatever happens to be in the caller's directory.
+unset CDPATH
+SCRIPT_DIR=$(cd -- "$(dirname -- "$0")" && pwd)
+cd "$SCRIPT_DIR"
 
-curl -fsSL https://bazel.build/bazel-release.pub.gpg | gpg --dearmor > bazel.gpg
-sudo mv bazel.gpg /etc/apt/trusted.gpg.d/ 
-echo "deb [arch=amd64] https://storage.googleapis.com/bazel-apt stable jdk1.8" | sudo tee /etc/apt/sources.list.d/bazel.list
-curl https://bazel.build/bazel-release.pub.gpg | sudo apt-key add -
-sudo apt update && sudo apt install bazel=6.0.0 -y
-sudo apt install clang-format -y
-rm $PWD/.git/hooks/pre-push
-ln -s $PWD/hooks/pre-push $PWD/.git/hooks/pre-push
+# Containers and cloud-init run this as root, where sudo is usually not
+# installed. Everywhere else it is needed to install packages.
+if [ "$(id -u)" -eq 0 ]; then
+  SUDO=""
+else
+  SUDO="sudo"
+fi
 
-bazel --version
-ret=$?
+# The Bazel apt repository only publishes amd64 packages, so Bazelisk is used
+# instead. Bazelisk reads .bazelversion and fetches that exact Bazel release.
+# Bazelisk itself only publishes linux-amd64 and linux-arm64, so those are the
+# architectures this script can install; anything else stops with a clear
+# message rather than part way through.
+ARCH=$(dpkg --print-architecture)
+case "$ARCH" in
+  amd64) BAZELISK_SHA256="$BAZELISK_SHA256_amd64" ;;
+  arm64) BAZELISK_SHA256="$BAZELISK_SHA256_arm64" ;;
+  *)
+    echo "INSTALL.sh: unsupported architecture '$ARCH' (expected amd64 or arm64)" >&2
+    exit 1
+    ;;
+esac
 
-if [[ $ret != "0" ]]; then
+$SUDO env DEBIAN_FRONTEND=noninteractive apt-get update
+$SUDO env DEBIAN_FRONTEND=noninteractive apt-get install -y \
+  build-essential \
+  ca-certificates \
+  clang-format \
+  curl \
+  default-jre-headless \
+  protobuf-compiler \
+  python3-dev \
+  rapidjson-dev \
+  unzip \
+  zip
 
-sudo apt-get install build-essential openjdk-11-jdk zip unzip -y
-rm bazel-6.0.0-dist.zip
-rm -rf bazel_build
-wget wget https://releases.bazel.build/6.0.0/release/bazel-6.0.0-dist.zip
-mkdir -p bazel_build
-mv bazel-6.0.0-dist.zip bazel_build/
-cd bazel_build
+# Download as the invoking user, verify against the published checksum, and
+# only then install over the system binary. Installing straight from curl would
+# leave a truncated executable behind if the transfer were interrupted.
+STAGE_DIR=$(mktemp -d)
+cleanup() {
+  status=$?
+  trap - EXIT
+  rm -rf "$STAGE_DIR"
+  exit "$status"
+}
+trap cleanup EXIT
+trap 'exit 129' HUP
+trap 'exit 130' INT
+trap 'exit 143' TERM
 
-unzip bazel-6.0.0-dist.zip
+curl -fsSL -o "$STAGE_DIR/bazelisk" \
+  "https://github.com/bazelbuild/bazelisk/releases/download/${BAZELISK_VERSION}/bazelisk-linux-${ARCH}"
+echo "${BAZELISK_SHA256}  ${STAGE_DIR}/bazelisk" | sha256sum -c -
+$SUDO install -m 0755 "$STAGE_DIR/bazelisk" "$BAZEL_BIN"
 
-export JAVA_HOME='/usr/lib/jvm/java-1.11.0-openjdk-arm64/'
-env EXTRA_BAZEL_ARGS="--host_javabase=@local_jdk//:jdk" bash ./compile.sh
-sudo cp output/bazel /usr/local/bin/
-cd ..
-rm -rf bazel_build
+# Call the installed binary directly; an unrelated bazel earlier in PATH would
+# otherwise decide which Bazel the rest of this script uses.
+"$BAZEL_BIN" --version
 
+# The pre-push hook is optional; only link it when it is present.
+if [ -f "$SCRIPT_DIR/hooks/pre-push" ] && [ -d "$SCRIPT_DIR/.git/hooks" ]; then
+  rm -f "$SCRIPT_DIR/.git/hooks/pre-push"
+  ln -s "$SCRIPT_DIR/hooks/pre-push" "$SCRIPT_DIR/.git/hooks/pre-push"
 fi
 
 # install buildifier
-bazel build @com_github_bazelbuild_buildtools//buildifier:buildifier
-
-sudo apt-get install python3.10-dev -y
-sudo apt-get install python3-dev -y
-
-
+"$BAZEL_BIN" build @com_github_bazelbuild_buildtools//buildifier:buildifier

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -22,6 +22,7 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
     name = "hedron_compile_commands",
+    sha256 = "658122cfb1f25be76ea212b00f5eb047d8e2adc8bcf923b918461f2b1e37cdf2",
     strip_prefix = "bazel-compile-commands-extractor-4f28899228fb3ad0126897876f147ca15026151e",
     #Replace the commit hash (4f28899228fb3ad0126897876f147ca15026151e) with the latest commit hash from the repo
     url = "https://github.com/hedronvision/bazel-compile-commands-extractor/archive/4f28899228fb3ad0126897876f147ca15026151e.tar.gz",
@@ -111,12 +112,13 @@ http_archive(
     urls = ["https://github.com/google/glog/archive/v0.5.0.zip"],
 )
 
-load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
-
-git_repository(
+# Fetched as a checksummed archive rather than by git tag: a tag can be moved
+# to a different commit upstream, which would silently change what is built.
+http_archive(
     name = "com_google_protobuf",
-    remote = "https://github.com/protocolbuffers/protobuf",
-    tag = "v3.10.0",
+    sha256 = "758249b537abba2f21ebc2d02555bf080917f0f2f88f4cbe2903e0e28c4187ed",
+    strip_prefix = "protobuf-3.10.0",
+    urls = ["https://github.com/protocolbuffers/protobuf/archive/refs/tags/v3.10.0.tar.gz"],
 )
 
 load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
@@ -200,8 +202,7 @@ http_archive(
     # This zip is just flat: duckdb.cpp, duckdb.hpp, duckdb.h at the root.
     # So no strip_prefix is needed.
     build_file = "//third_party:duckdb.BUILD",
-    # Optional: you can add sha256 once Bazel prints it for you.
-    # sha256 = "<FILL_ME_FROM_BAZEL_ERROR>",
+    sha256 = "d1efda5fabc198d2099109f2d6a21392a7ca3888afbafe8573abcb1b09c6f15a",
 )
 
 
@@ -233,6 +234,7 @@ http_archive(
 
 http_archive(
     name = "pybind11_bazel",
+    sha256 = "044d334a269e03edf4c7f8a3315d1dbf59177b8ddf1c38178bcc72cc73a93aba",
     strip_prefix = "pybind11_bazel-2.11.1.bzl.1",
     urls = ["https://github.com/pybind/pybind11_bazel/archive/refs/tags/v2.11.1.bzl.1.zip"],
 )

--- a/chain/state/chain_state.h
+++ b/chain/state/chain_state.h
@@ -19,6 +19,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <map>
 #include <unordered_map>
 

--- a/chain/storage/duckdb.h
+++ b/chain/storage/duckdb.h
@@ -18,6 +18,7 @@
  */
 #pragma once
 
+#include <cstdint>
 #include <map>
 #include <memory>
 #include <optional>

--- a/chain/storage/leveldb.h
+++ b/chain/storage/leveldb.h
@@ -19,6 +19,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <memory>
 #include <optional>
 #include <string>

--- a/chain/storage/memory_db.h
+++ b/chain/storage/memory_db.h
@@ -19,6 +19,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <list>
 #include <map>
 #include <memory>

--- a/chain/storage/mock_storage.h
+++ b/chain/storage/mock_storage.h
@@ -19,6 +19,8 @@
 
 #pragma once
 
+#include <cstdint>
+
 #include "chain/storage/storage.h"
 #include "gmock/gmock.h"
 

--- a/chain/storage/storage.h
+++ b/chain/storage/storage.h
@@ -19,6 +19,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <map>
 #include <string>
 #include <vector>

--- a/common/crypto/signature_verifier.h
+++ b/common/crypto/signature_verifier.h
@@ -22,6 +22,7 @@
 #include <cryptopp/filters.h>
 #include <cryptopp/xed25519.h>
 
+#include <cstdint>
 #include <shared_mutex>
 #include <string>
 

--- a/executor/common/transaction_manager.h
+++ b/executor/common/transaction_manager.h
@@ -19,6 +19,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <memory>
 
 #include "chain/storage/storage.h"

--- a/executor/contract/manager/contract_manager.h
+++ b/executor/contract/manager/contract_manager.h
@@ -19,6 +19,8 @@
 
 #pragma once
 
+#include <cstdint>
+
 #include "absl/status/statusor.h"
 #include "chain/storage/storage.h"
 #include "eEVM/opcode.h"

--- a/executor/contract/manager/evm_state.h
+++ b/executor/contract/manager/evm_state.h
@@ -19,6 +19,8 @@
 
 #pragma once
 
+#include <cstdint>
+
 #include "eEVM/globalstate.h"
 
 namespace resdb {

--- a/executor/utxo/manager/transaction.h
+++ b/executor/utxo/manager/transaction.h
@@ -19,6 +19,8 @@
 
 #pragma once
 
+#include <cstdint>
+
 #include "absl/status/statusor.h"
 #include "executor/utxo/manager/tx_mempool.h"
 #include "executor/utxo/manager/wallet.h"

--- a/executor/utxo/manager/tx_mempool.h
+++ b/executor/utxo/manager/tx_mempool.h
@@ -19,6 +19,8 @@
 
 #pragma once
 
+#include <cstdint>
+
 #include "absl/status/statusor.h"
 #include "proto/utxo/utxo.pb.h"
 

--- a/executor/utxo/manager/wallet.h
+++ b/executor/utxo/manager/wallet.h
@@ -19,6 +19,8 @@
 
 #pragma once
 
+#include <cstdint>
+
 #include "proto/utxo/utxo.pb.h"
 
 namespace resdb {

--- a/interface/common/mock_resdb_txn_accessor.h
+++ b/interface/common/mock_resdb_txn_accessor.h
@@ -21,6 +21,8 @@
 
 #include <gmock/gmock.h>
 
+#include <cstdint>
+
 #include "interface/common/resdb_txn_accessor.h"
 
 namespace resdb {

--- a/interface/common/resdb_txn_accessor.h
+++ b/interface/common/resdb_txn_accessor.h
@@ -19,6 +19,8 @@
 
 #pragma once
 
+#include <cstdint>
+
 #include "absl/status/statusor.h"
 #include "interface/rdbc/net_channel.h"
 #include "platform/config/resdb_config.h"

--- a/interface/rdbc/mock_resdb_txn_accessor.h
+++ b/interface/rdbc/mock_resdb_txn_accessor.h
@@ -21,6 +21,8 @@
 
 #include <gmock/gmock.h>
 
+#include <cstdint>
+
 #include "platform/interface/resdb_txn_accessor.h"
 
 namespace resdb {

--- a/interface/rdbc/transaction_constructor.h
+++ b/interface/rdbc/transaction_constructor.h
@@ -19,6 +19,8 @@
 
 #pragma once
 
+#include <cstdint>
+
 #include "absl/status/statusor.h"
 #include "interface/rdbc/net_channel.h"
 #include "platform/config/resdb_config.h"

--- a/interface/utxo/utxo_client.h
+++ b/interface/utxo/utxo_client.h
@@ -19,6 +19,8 @@
 
 #pragma once
 
+#include <cstdint>
+
 #include "interface/rdbc/transaction_constructor.h"
 #include "proto/utxo/utxo.pb.h"
 

--- a/platform/common/network/socket.h
+++ b/platform/common/network/socket.h
@@ -19,6 +19,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <memory>
 #include <string>
 

--- a/platform/common/network/tcp_socket.h
+++ b/platform/common/network/tcp_socket.h
@@ -19,6 +19,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <string>
 
 #include "platform/common/network/socket.h"

--- a/platform/common/queue/blocking_queue.h
+++ b/platform/common/queue/blocking_queue.h
@@ -22,6 +22,7 @@
 #include <glog/logging.h>
 
 #include <condition_variable>
+#include <cstdint>
 #include <queue>
 
 #include "absl/status/statusor.h"

--- a/platform/config/resdb_config.h
+++ b/platform/config/resdb_config.h
@@ -19,6 +19,8 @@
 
 #pragma once
 
+#include <cstdint>
+
 #include "common/proto/signature_info.pb.h"
 #include "platform/proto/replica_info.pb.h"
 

--- a/platform/config/resdb_poc_config.h
+++ b/platform/config/resdb_poc_config.h
@@ -19,6 +19,8 @@
 
 #pragma once
 
+#include <cstdint>
+
 #include "platform/config/resdb_config.h"
 
 namespace resdb {

--- a/platform/consensus/checkpoint/checkpoint.h
+++ b/platform/consensus/checkpoint/checkpoint.h
@@ -19,6 +19,8 @@
 
 #pragma once
 
+#include <cstdint>
+
 namespace resdb {
 
 class CheckPoint {

--- a/platform/consensus/checkpoint/mock_checkpoint.h
+++ b/platform/consensus/checkpoint/mock_checkpoint.h
@@ -21,6 +21,8 @@
 
 #include <gmock/gmock.h>
 
+#include <cstdint>
+
 #include "platform/consensus/checkpoint/checkpoint.h"
 
 namespace resdb {

--- a/platform/consensus/execution/geo_global_executor.h
+++ b/platform/consensus/execution/geo_global_executor.h
@@ -18,6 +18,7 @@
  */
 
 #pragma once
+#include <cstdint>
 #include <mutex>
 #include <queue>
 #include <unordered_map>

--- a/platform/consensus/execution/system_info.h
+++ b/platform/consensus/execution/system_info.h
@@ -19,6 +19,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <memory>
 
 #include "platform/config/resdb_config.h"

--- a/platform/consensus/execution/transaction_executor.h
+++ b/platform/consensus/execution/transaction_executor.h
@@ -18,6 +18,7 @@
  */
 
 #pragma once
+#include <cstdint>
 #include <functional>
 #include <thread>
 

--- a/platform/consensus/ordering/common/framework/performance_manager.h
+++ b/platform/consensus/ordering/common/framework/performance_manager.h
@@ -19,6 +19,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <future>
 
 #include "platform/config/resdb_config.h"

--- a/platform/consensus/ordering/common/framework/response_manager.h
+++ b/platform/consensus/ordering/common/framework/response_manager.h
@@ -19,6 +19,8 @@
 
 #pragma once
 
+#include <cstdint>
+
 #include "platform/config/resdb_config.h"
 #include "platform/consensus/ordering/common/framework/transaction_utils.h"
 #include "platform/networkstrate/replica_communicator.h"

--- a/platform/consensus/ordering/geo_pbft/geo_pbft_commitment.h
+++ b/platform/consensus/ordering/geo_pbft/geo_pbft_commitment.h
@@ -19,6 +19,8 @@
 
 #pragma once
 
+#include <cstdint>
+
 #include "platform/config/resdb_config.h"
 #include "platform/consensus/execution/geo_global_executor.h"
 #include "platform/consensus/execution/system_info.h"

--- a/platform/consensus/ordering/pbft/checkpoint_manager.h
+++ b/platform/consensus/ordering/pbft/checkpoint_manager.h
@@ -21,6 +21,8 @@
 
 #include <semaphore.h>
 
+#include <cstdint>
+
 #include "chain/state/chain_state.h"
 #include "common/crypto/signature_verifier.h"
 #include "interface/common/resdb_txn_accessor.h"

--- a/platform/consensus/ordering/pbft/commitment.h
+++ b/platform/consensus/ordering/pbft/commitment.h
@@ -19,6 +19,8 @@
 
 #pragma once
 
+#include <cstdint>
+
 #include "platform/common/queue/batch_queue.h"
 #include "platform/config/resdb_config.h"
 #include "platform/consensus/execution/duplicate_manager.h"

--- a/platform/consensus/ordering/pbft/consensus_manager_pbft.h
+++ b/platform/consensus/ordering/pbft/consensus_manager_pbft.h
@@ -19,6 +19,8 @@
 
 #pragma once
 
+#include <cstdint>
+
 #include "executor/common/custom_query.h"
 #include "platform/config/resdb_config.h"
 #include "platform/consensus/ordering/pbft/checkpoint_manager.h"

--- a/platform/consensus/ordering/pbft/lock_free_collector_pool.h
+++ b/platform/consensus/ordering/pbft/lock_free_collector_pool.h
@@ -19,6 +19,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <vector>
 
 #include "platform/consensus/ordering/pbft/transaction_collector.h"

--- a/platform/consensus/ordering/pbft/mock_checkpoint_manager.h
+++ b/platform/consensus/ordering/pbft/mock_checkpoint_manager.h
@@ -21,6 +21,8 @@
 
 #include <gmock/gmock.h>
 
+#include <cstdint>
+
 #include "platform/consensus/ordering/pbft/checkpoint_manager.h"
 
 namespace resdb {

--- a/platform/consensus/ordering/pbft/performance_manager.h
+++ b/platform/consensus/ordering/pbft/performance_manager.h
@@ -21,6 +21,7 @@
 
 #include <semaphore.h>
 
+#include <cstdint>
 #include <future>
 #include <queue>
 

--- a/platform/consensus/ordering/pbft/response_manager.h
+++ b/platform/consensus/ordering/pbft/response_manager.h
@@ -20,6 +20,8 @@
 #pragma once
 #include <semaphore.h>
 
+#include <cstdint>
+
 #include "platform/config/resdb_config.h"
 #include "platform/consensus/ordering/pbft/lock_free_collector_pool.h"
 #include "platform/consensus/ordering/pbft/transaction_utils.h"

--- a/platform/consensus/ordering/pbft/transaction_collector.h
+++ b/platform/consensus/ordering/pbft/transaction_collector.h
@@ -20,6 +20,7 @@
 #pragma once
 
 #include <bitset>
+#include <cstdint>
 
 #include "platform/consensus/execution/transaction_executor.h"
 #include "platform/networkstrate/server_comm.h"

--- a/platform/consensus/ordering/pbft/viewchange_manager.h
+++ b/platform/consensus/ordering/pbft/viewchange_manager.h
@@ -21,6 +21,8 @@
 
 #include <semaphore.h>
 
+#include <cstdint>
+
 #include "common/crypto/signature_verifier.h"
 #include "platform/config/resdb_config.h"
 #include "platform/consensus/execution/system_info.h"

--- a/platform/consensus/ordering/poc/pow/block_manager.h
+++ b/platform/consensus/ordering/poc/pow/block_manager.h
@@ -19,6 +19,8 @@
 
 #pragma once
 
+#include <cstdint>
+
 #include "absl/status/status.h"
 #include "platform/config/resdb_poc_config.h"
 #include "platform/consensus/ordering/poc/pow/miner.h"

--- a/platform/consensus/ordering/poc/pow/miner.h
+++ b/platform/consensus/ordering/poc/pow/miner.h
@@ -18,6 +18,9 @@
  */
 
 #pragma once
+
+#include <cstdint>
+
 #include "absl/status/status.h"
 #include "platform/config/resdb_poc_config.h"
 #include "platform/consensus/ordering/poc/proto/pow.pb.h"

--- a/platform/consensus/ordering/poc/pow/miner_utils.h
+++ b/platform/consensus/ordering/poc/pow/miner_utils.h
@@ -19,6 +19,8 @@
 
 #pragma once
 
+#include <cstdint>
+
 #include "platform/consensus/ordering/poc/proto/pow.pb.h"
 
 namespace resdb {

--- a/platform/consensus/ordering/poc/pow/mock_transaction_accessor.h
+++ b/platform/consensus/ordering/poc/pow/mock_transaction_accessor.h
@@ -19,6 +19,8 @@
 
 #pragma once
 
+#include <cstdint>
+
 #include "gmock/gmock.h"
 #include "platform/consensus/ordering/poc/pow/transaction_accessor.h"
 

--- a/platform/consensus/ordering/poc/pow/shift_manager.h
+++ b/platform/consensus/ordering/poc/pow/shift_manager.h
@@ -20,6 +20,7 @@
 #pragma once
 
 #include <condition_variable>
+#include <cstdint>
 
 #include "platform/config/resdb_poc_config.h"
 #include "platform/consensus/ordering/poc/proto/pow.pb.h"

--- a/platform/consensus/ordering/poc/pow/transaction_accessor.h
+++ b/platform/consensus/ordering/poc/pow/transaction_accessor.h
@@ -19,6 +19,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <thread>
 
 #include "interface/common/resdb_txn_accessor.h"

--- a/platform/consensus/ordering/poe/algorithm/poe.h
+++ b/platform/consensus/ordering/poe/algorithm/poe.h
@@ -19,6 +19,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <deque>
 #include <map>
 #include <queue>

--- a/platform/consensus/ordering/poe/framework/consensus.h
+++ b/platform/consensus/ordering/poe/framework/consensus.h
@@ -19,6 +19,8 @@
 
 #pragma once
 
+#include <cstdint>
+
 #include "executor/common/transaction_manager.h"
 #include "platform/consensus/ordering/common/framework/consensus.h"
 #include "platform/consensus/ordering/poe/algorithm/poe.h"

--- a/platform/consensus/recovery/recovery.h
+++ b/platform/consensus/recovery/recovery.h
@@ -19,6 +19,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <thread>
 
 #include "chain/storage/storage.h"

--- a/platform/networkstrate/consensus_manager.h
+++ b/platform/networkstrate/consensus_manager.h
@@ -19,6 +19,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <thread>
 
 #include "platform/common/queue/blocking_queue.h"

--- a/platform/networkstrate/mock_replica_communicator.h
+++ b/platform/networkstrate/mock_replica_communicator.h
@@ -21,6 +21,8 @@
 
 #include <gmock/gmock.h>
 
+#include <cstdint>
+
 #include "platform/networkstrate/replica_communicator.h"
 
 namespace resdb {

--- a/platform/networkstrate/replica_communicator.h
+++ b/platform/networkstrate/replica_communicator.h
@@ -18,6 +18,7 @@
  */
 
 #pragma once
+#include <cstdint>
 #include <thread>
 
 #include "interface/rdbc/net_channel.h"

--- a/platform/statistic/stats.h
+++ b/platform/statistic/stats.h
@@ -22,6 +22,7 @@
 #include <crow.h>
 
 #include <chrono>
+#include <cstdint>
 #include <future>
 #include <nlohmann/json.hpp>
 

--- a/repositories.bzl
+++ b/repositories.bzl
@@ -56,8 +56,13 @@ def nexres_repositories():
     maybe(
         http_archive,
         name = "com_google_absl",
-        strip_prefix = "abseil-cpp-20211102.0",
-        urls = ["https://github.com/abseil/abseil-cpp/archive/refs/tags/20211102.0.zip"],
+        # 20250127.0 and newer select on @rules_cc//cc/compiler, which the
+        # rules_cc bundled with Bazel 6.0.0 does not provide, and fail during
+        # analysis. 20240722.2 builds with Bazel 6.0.0 and carries the
+        # <cstdint> includes that GCC 13+ requires.
+        sha256 = "f43db925dcfb480e49019f25094ba26ac9ff55b37ebeceff3637575b4b07b382",
+        strip_prefix = "abseil-cpp-20240722.2",
+        urls = ["https://github.com/abseil/abseil-cpp/archive/refs/tags/20240722.2.zip"],
     )
     maybe(
         http_archive,
@@ -87,7 +92,9 @@ def nexres_repositories():
         sha256 = "91844808532e5ce316b3c010929493c0244f3d37593afd6de04f71821d5136d9",
         strip_prefix = "zlib-1.2.12",
         urls = [
-            "https://zlib.net/zlib-1.2.12.tar.gz",
+            # zlib.net serves only the current release from the top level and
+            # moves older ones under fossils/, so the unprefixed URL 404s.
+            "https://zlib.net/fossils/zlib-1.2.12.tar.gz",
             "https://storage.googleapis.com/bazel-mirror/zlib.net/zlib-1.2.12.tar.gz",
         ],
     )

--- a/repositories.bzl
+++ b/repositories.bzl
@@ -22,6 +22,16 @@ load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
 all_content = """filegroup(name = "all_srcs", srcs = glob(["**"]), visibility = ["//visibility:public"])"""
 
 def nexres_repositories():
+    # Declared here so the version is chosen deliberately. Abseil needs
+    # config_setting_group from lib/selects.bzl, which the skylib that
+    # protobuf 3.10 pins does not have; without this the build only works
+    # because rules_foreign_cc happens to register 1.0.3 first.
+    maybe(
+        http_archive,
+        name = "bazel_skylib",
+        sha256 = "1c531376ac7e5a180e0237938a2536de0c54d93f5c278634818e0efc952dd56c",
+        urls = ["https://github.com/bazelbuild/bazel-skylib/releases/download/1.0.3/bazel-skylib-1.0.3.tar.gz"],
+    )
     maybe(
         http_archive,
         name = "eEVM",
@@ -42,6 +52,7 @@ def nexres_repositories():
     maybe(
         http_archive,
         name = "com_github_nelhage_rules_boost",
+        sha256 = "5ea00abc70cdf396a23fb53201db19ebce2837d28887a08544429d27783309ed",
         strip_prefix = "rules_boost-96e9b631f104b43a53c21c87b01ac538ad6f3b48",
         url = "https://github.com/nelhage/rules_boost/archive/96e9b631f104b43a53c21c87b01ac538ad6f3b48.tar.gz",
     )

--- a/service/tools/kv/api_tools/kv_service_tools.cpp
+++ b/service/tools/kv/api_tools/kv_service_tools.cpp
@@ -124,7 +124,9 @@ int main(int argc, char** argv) {
   std::string sql;
   std::string client_config_file;
   int top = 0;
-  char c;
+  // getopt_long returns int and signals the end of the options with -1. Storing
+  // that in a char loops forever where char is unsigned, as it is on arm64.
+  int c;
   std::string cmd;
 
   if (argc >= 3) {

--- a/third_party/z.BUILD
+++ b/third_party/z.BUILD
@@ -29,6 +29,11 @@ cc_library(
     copts = [
         "-w",
         "-Dverbose=-1",
+        # zlib's ./configure normally sets this in zconf.h. Bazel builds the
+        # sources directly, so without it zconf.h skips <unistd.h> and the gz*
+        # sources call write()/close()/lseek() undeclared. That is an error
+        # rather than a warning from GCC 14 on, and -w does not suppress it.
+        "-DZ_HAVE_UNISTD_H",
     ],
     includes = ["."],
 )


### PR DESCRIPTION

Closes #245

## The problem

The README states `OS Requirements: Ubuntu 20+` and tells users to run
`./INSTALL.sh`. I could not get that to work on Ubuntu 24.04 on either
architecture, nor on 26.04/arm64, and on arm64 it fails before Bazel is
installed at all.

Reproduction, on a machine that has `sudo`, `curl` and `wget`, which is what a
normal Ubuntu install has:

```
docker run --rm -it --platform linux/arm64 ubuntu:24.04 bash
apt-get update && apt-get install -y sudo curl wget gnupg ca-certificates git
git clone https://github.com/apache/incubator-resilientdb && cd incubator-resilientdb
./INSTALL.sh; echo "exit=$?"
```

On `master` this prints a series of failures and then:

```
exit=0
```

Several commands failed, but the script has no `set -e` and kept going. The
final `apt-get install python3-dev` succeeded, so the run exits 0 and reports
success. Bazel is not installed. The failure surfaces later as a confusing
error from a build that cannot start.

## What actually breaks

**1. Bazel cannot be installed on arm64.** `INSTALL.sh` adds the Bazel apt
repository with `[arch=amd64]`. That repository's `Release` file declares
`Architectures: amd64` and has no arm64 index, so apt selects `bazel:amd64` and
then cannot satisfy `g++:amd64`:

```
 bazel:amd64 : Depends: g++:amd64 but it is not installable
E: Unable to correct problems, you have held broken packages.
```

The script then falls back to compiling Bazel 6.0.0 from source, and that fails
too, for a different reason on each release. Bazel 6.0.0 vendors dependencies
about as old as this repository's own, so it hits the same problems:

- On 24.04 (GCC 13), while compiling Bazel's bundled Abseil:

  ```
  external/com_google_absl/absl/strings/internal/str_format/extension.h:34:33:
    error: found ':' in nested-name-specifier, expected '::'
  ```

- On 26.04 (GCC 15), while compiling Bazel's bundled zlib:

  ```
  external/net_zlib_zlib/gzwrite.c:89:20: error: implicit declaration of
    function 'write'; did you mean 'fwrite'?
  ```

Two smaller things in the same run: `apt-key` is deprecated on 22.04 and 24.04
and no longer exists on 26.04, where it reports `apt-key: command not found`
(the keyring line above it already does the same job); and `python3.10-dev` is
hardcoded, so on 24.04 the run also reports `E: Unable to locate package
python3.10-dev`.

**2. Abseil 20211102.0 does not compile with GCC 13+.** It declares fixed-width
integer types without including `<cstdint>`. This is the same failure the
bundled copy inside Bazel produces above.

**3. 53 headers in the core tree have the same problem.** They name `uint64_t`
and friends and rely on another header to provide `<cstdint>`. (`ecosystem/` is
a separate Bazel workspace excluded via `.bazelignore`; its one affected header
is covered in the GraphQL issue below.)

**4. The vendored zlib misses `<unistd.h>`.** `./configure` normally sets
`Z_HAVE_UNISTD_H` in `zconf.h`; Bazel compiles the sources directly, so the
`gz*` sources call `write()`/`close()`/`lseek()` undeclared. GCC 14 turned that
into an error.

**5. `kv_service_tools` spins forever on arm64.** `getopt_long` returns `int`
and signals the end of the options with `-1`, but the result was stored in a
`char`. GCC on Linux/AArch64 defaults plain `char` to unsigned, so `-1` became
`255`, the loop condition never became false, and the tool sat at 100% CPU
inside `getopt_long` while the replicas reported `socket recv:0`:

```
#0  getopt_long (argc=11, ..., options="h", ...) at ./posix/getopt1.c:33
#1  main ()
```

This affects every option-style invocation, which is the interface the README
documents. The older positional `get`/`set`/`getvalues`/`getrange` path returns
before this loop and is unaffected. GCC defaults `char` to signed on x86-64,
which is why it was never seen there.

## Why these fixes and not the obvious ones

**zlib is not upgraded.** The obvious fix is a version bump, and it does not
work. Compiling `gzwrite.c` with GCC 15:

| zlib | no define | `-DZ_HAVE_UNISTD_H` |
|---|---|---|
| 1.2.12 | fails | builds |
| 1.3.2 | fails | builds |

The guard in `zconf.h` depends on the build configuration rather than on the
release, so the pin is left alone and the define is added instead.

**Abseil is not moved to the newest release.** 20250127.0 and later select on
`@rules_cc//cc/compiler`, which the rules_cc bundled with Bazel 6.0.0 does not
provide; the build fails during analysis. 20240722.2 built successfully in the
matrix below. The tree's only direct Abseil labels are `absl/status` and
`absl/status:statusor` (`common/BUILD:21`), and the bump needed no ResilientDB
source changes.

**Bazelisk is not a new idea.** `Docker/Dockerfile_mac:39` already installs
Bazel this way for arm64, though unpinned. It reads `.bazelversion`, so the
pinned Bazel 6.0.0 is unchanged; only how it is obtained differs. Here it is
pinned to v1.29.0 and verified against the SHA-256 published with that release
before being installed.

**All 53 headers get `<cstdint>`, not only the ones that break today.** Every
changed header directly names a fixed-width integer type. Some fail now and
others currently compile through a transitive include; adding the direct
include makes that explicit rather than dependent on what other headers happen
to pull in. Taking each header's own `#include <...>` lines and compiling them
against a `uint64_t` declaration, 43 of the 53 cannot obtain the type that way
and 10 can.

## Verification

Each row was run from a clean container: `./INSTALL.sh`, then
`bazel build //service/kv:kv_service`.

| OS | arch | GCC | Python | install | build |
|---|---|---|---|---|---|
| 22.04 | arm64 | 11.4.0 | 3.10 | ok | ok, 404 actions |
| 24.04 | amd64 | 13.3.0 | 3.12 | ok | ok, 406 actions |
| 24.04 | arm64 | 13.3.0 | 3.12 | ok | ok, 404 actions |
| 26.04 | arm64 | 15.2.0 | 3.14 | ok | ok, 636 actions |

22.04 is the oldest release tested here; the README also lists 20.04, which I
did not test. Every run reports the Bazel 6.0.0 pinned in `.bazelversion`.

The path the README describes also completes on 26.04/arm64, which it did not
before:

```sh
./INSTALL.sh                                                # exit 0, bazel 6.0.0
./service/tools/kv/server_tools/generate_keys_and_certs.sh  # exit 0, 17 files
./service/tools/kv/server_tools/start_kv_service.sh         # exit 0, 5 nodes
bazel build service/tools/kv/api_tools/kv_service_tools     # exit 0

bazel-bin/service/tools/kv/api_tools/kv_service_tools \
  --config service/tools/config/interface/service.config \
  --cmd set_with_version --key key1 --value hello_apache --version 0
    set key = key1, value = hello_apache, version = 0 done, ret = 0
    current value = value: "hello_apache"
    version: 1

bazel-bin/service/tools/kv/api_tools/kv_service_tools \
  --config service/tools/config/interface/service.config \
  --cmd get_with_version --key key1 --version 0
    get key = key1, value = value: "hello_apache"
    version: 1
```

`shellcheck -s sh` (0.10.0), `checkbashisms` and `dash -n` are clean on
`INSTALL.sh`. `clang-format --dry-run --Werror` reports no header that was
clean on `master` and is not clean here.

Two additions to the apt list deserve a word: `ca-certificates` is required for
the curl download of Bazelisk, and `default-jre-headless` plus `zip`/`unzip`
are what `dev/check-license` needs to run Apache RAT — Bazel itself ships its
own JDK and does not need them.

## Why CI did not catch any of this

`build.yml:45` and `ut.yml:45` pin Python 3.10, and `build.yml:62` and
`ut.yml:59` pin `CC=gcc-11`, which is what Ubuntu 22.04 ships — so the GCC
13/14 failures cannot appear in the PR-gating workflows. The one arm64 build
that does exist is `build-push.yml`'s Docker image job: it runs post-merge on
master only, is skipped when Docker Hub credentials are absent, uses an Ubuntu
20.04 base (old toolchain, so the compiler failures cannot appear there
either), and builds `kv_service_tools` without ever running it, so the getopt
spin stays invisible too.

No workflow is changed or added here. Coverage that uses the distribution's own
toolchain would stop this recurring, but that is a decision about CI policy and
runner budget rather than part of this fix, and it is easier to discuss on its
own. Happy to send it separately.

## A note on architecture support

Bazelisk publishes only `linux-amd64` and `linux-arm64`, so the rewritten
script stops with a clear message on any other Debian architecture rather than
failing part way through. The previous source-compilation fallback was not
architecture-limited in principle, although it does not complete on any release
I tested. If ppc64el or s390x matter, that needs a different way of obtaining
Bazel and I have not attempted it.

## Deliberately not included

- **`bazel build ...` still fails**, because pybind11 2.6.2 does not compile
  against Python 3.11+. `//service/kv:kv_service` has no pybind11 in its
  dependency graph and is unaffected. Filed as #262.
- **`ecosystem/graphql/WORKSPACE:224`** fetches this project with
  `git_repository(branch = "master")`, so a GraphQL build uses remote master
  rather than the checkout and none of these fixes reach it. Changing how a
  subproject depends on its parent is an architectural decision for the
  maintainers. Filed as #263.
- **`Docker/Dockerfile`, `INSTALL/README.md` and the Ansible role** each
  install Bazel their own way, one of them still using `apt-key`. Consolidating
  them is a separate change.
- **`rapidjson-dev` and `protobuf-compiler`** appear to have no consumer left
  in the core tree, but they predate this change and removing them is unrelated
  cleanup.

## Commits

The dependency pinning in commit 5 is independent of the rest: `protobuf` moves
off a mutable git tag, four archives that had no `sha256` get one, and
`bazel_skylib` is pinned to the 1.0.3 that already wins today so that the
choice is deliberate rather than a side effect of macro ordering. Drop that
commit if it is out of scope for this PR; nothing else depends on it.
